### PR TITLE
Order test

### DIFF
--- a/app/code/community/PriceWaiter/NYPWidget/Helper/Data.php
+++ b/app/code/community/PriceWaiter/NYPWidget/Helper/Data.php
@@ -20,12 +20,6 @@
 class PriceWaiter_NYPWidget_Helper_Data extends Mage_Core_Helper_Abstract
 {
     private $_product = false;
-    private $_testing = false;
-
-    public function isTesting()
-    {
-        return $this->_testing;
-    }
 
     public function isEnabledForStore()
     {
@@ -100,12 +94,10 @@ class PriceWaiter_NYPWidget_Helper_Data extends Mage_Core_Helper_Abstract
 
     public function getWidgetUrl()
     {
-        if ($this->_testing) {
-            return "https://widget-staging.pricewaiter.com/nyp/script/widget.js";
-        } elseif ($this->isEnabledForStore()) {
+        if ($this->isEnabledForStore()) {
             return "https://widget.pricewaiter.com/script/"
-            . Mage::getStoreConfig('pricewaiter/configuration/api_key')
-            . ".js";
+                . Mage::getStoreConfig('pricewaiter/configuration/api_key')
+                . ".js";
         }
 
         return "https://widget.pricewaiter.com/nyp/script/widget.js";
@@ -113,14 +105,8 @@ class PriceWaiter_NYPWidget_Helper_Data extends Mage_Core_Helper_Abstract
 
     public function getApiUrl()
     {
-        if ($this->_testing) {
-            return "https://api-staging.pricewaiter.com/1/order/verify?"
-            . "api_key="
+        return "https://api.pricewaiter.com/1/order/verify?api_key="
             . Mage::getStoreConfig('pricewaiter/configuration/api_key');
-        } else {
-            return "https://api.pricewaiter.com/1/order/verify?api_key="
-            . Mage::getStoreConfig('pricewaiter/configuration/api_key');
-        }
     }
 
     public function getProductPrice($product)

--- a/app/code/community/PriceWaiter/NYPWidget/Model/Callback.php
+++ b/app/code/community/PriceWaiter/NYPWidget/Model/Callback.php
@@ -32,27 +32,24 @@ class PriceWaiter_NYPWidget_Model_Callback
 
     public function processRequest($request)
     {
-        // If the PriceWaiter extension is in testing mode, skip request validation
-        if (!Mage::helper('nypwidget')->isTesting()) {
-            // Build URL to check validity of order notification.
-            $url = Mage::helper('nypwidget')->getApiUrl();
+        // Build URL to check validity of order notification.
+        $url = Mage::helper('nypwidget')->getApiUrl();
 
-            $ch = curl_init($url);
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-            curl_setopt($ch, CURLOPT_POST, true);
-            curl_setopt($ch, CURLOPT_POSTFIELDS, $request);
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $request);
 
-            // If PriceWaiter returns an invalid response
-            if (curl_exec($ch) == "1") {
-                $message = "The Name Your Price Widget has received a valid order notification.";
-                Mage::log($message);
-                $this->_log($message);
-            } else {
-                $message = "An invalid PriceWaiter order notification has been received.";
-                Mage::log($message);
-                $this->_log($message);
-                return;
-            }
+        // If PriceWaiter returns an invalid response
+        if (curl_exec($ch) == "1") {
+            $message = "The Name Your Price Widget has received a valid order notification.";
+            Mage::log($message);
+            $this->_log($message);
+        } else {
+            $message = "An invalid PriceWaiter order notification has been received.";
+            Mage::log($message);
+            $this->_log($message);
+            return;
         }
 
         // Verify that we have not already received this callback based on the `pricewaiter_id` field


### PR DESCRIPTION
Adds support for `test=1` parameter in Order Callback API.

When a test order is created, it is immediately canceled.

Also includes a bit of cleanup of unused code.