### PR TITLE
Add currency code support to widget and callback.

### DIFF
--- a/app/code/community/PriceWaiter/NYPWidget/Model/Callback.php
+++ b/app/code/community/PriceWaiter/NYPWidget/Model/Callback.php
@@ -110,14 +110,22 @@ class PriceWaiter_NYPWidget_Model_Callback
             $transaction = Mage::getModel('core/resource_transaction');
             $reservedOrderId = Mage::getSingleton('eav/config')->getEntityType('order')->fetchNewIncrementId($this->_store->getId());
 
+            // Grab the currency code from the request, if one is set.
+            // Otherwise, use the store's default currency code.
+            if ($request['currency']) {
+                $currencyCode = $request['currency'];
+            } else {
+                $currencyCode = $this->_store->getDefaultCurrencyCode();
+            }
+
             $order = Mage::getModel('sales/order')
                 ->setIncrementId($reservedOrderId)
                 ->setStoreId($this->_store->getId())
                 ->setQuoteId(0)
-                ->setGlobal_currency_code('USD')
-                ->setBase_currency_code('USD')
-                ->setStore_currency_code('USD')
-                ->setOrder_currency_code('USD');
+                ->setGlobal_currency_code($currencyCode)
+                ->setBase_currency_code($currencyCode)
+                ->setStore_currency_code($currencyCode)
+                ->setOrder_currency_code($currencyCode);
 
             // set Customer data
             $order->setCustomer_email($customer->getEmail())

--- a/app/design/frontend/base/default/template/pricewaiter/widget.phtml
+++ b/app/design/frontend/base/default/template/pricewaiter/widget.phtml
@@ -28,6 +28,7 @@
     $displayHoverColor = Mage::getStoreConfig('pricewaiter/appearance/display_hover_color');
     $brand = $_product->getData('brand');
     $image = $_product->getImageUrl();
+    $currency = Mage::app()->getStore()->getCurrentCurrencyCode();
     if ($helper->isEnabledForStore()):
         ?>
         <script type="text/javascript">
@@ -38,6 +39,7 @@
                 <?php else: ?>
                 enableButton: false,
                 <?php endif; ?>
+                currency: '<?php echo $currency; ?>',
                 button: {
                     type: <?php echo json_encode($displayPhrase); ?>,
                     size: <?php echo json_encode($displaySize); ?>,


### PR DESCRIPTION
This needs to be tested against the new callback testing functionality when the API's currency support is live.