### PR TITLE
Add manufacturer support

### DIFF
--- a/app/code/community/PriceWaiter/NYPWidget/etc/config.xml
+++ b/app/code/community/PriceWaiter/NYPWidget/etc/config.xml
@@ -18,7 +18,7 @@
 
     <modules>
         <PriceWaiter_NYPWidget>
-            <version>2.1.4</version>
+            <version>2.1.5</version>
         </PriceWaiter_NYPWidget>
     </modules>
 

--- a/app/design/frontend/base/default/template/pricewaiter/widget.phtml
+++ b/app/design/frontend/base/default/template/pricewaiter/widget.phtml
@@ -27,7 +27,7 @@
 
 
     // prefer brand, but fallback to manufacturer attribute
-    // getAttributeText will fail when manufacturer is deleted.
+    // getAttributeText will throw exception when manufacturer attribute is deleted.
     // getResource -> getAttribute will safely give Object when attribute exists
     $brand = $_product->getData('brand');
     $manufacturer_id = $_product->getResource()->getAttribute('manufacturer');

--- a/app/design/frontend/base/default/template/pricewaiter/widget.phtml
+++ b/app/design/frontend/base/default/template/pricewaiter/widget.phtml
@@ -26,7 +26,14 @@
     $extensionVersion = Mage::getConfig()->getNode()->modules->PriceWaiter_NYPWidget->version;
 
 
+    // prefer brand, but fallback to manufacturer attribute
     $brand = $_product->getData('brand');
+    $manufacturer = $_product->getAttributeText('manufacturer');
+
+    if (!$brand && $manufacturer) {
+        $brand = $manufacturer;
+    }
+
     $image = $_product->getImageUrl();
     $currency = Mage::app()->getStore()->getCurrentCurrencyCode();
     if ($_product->getTypeId() == Mage_Catalog_Model_Product_Type::TYPE_GROUPED) {

--- a/app/design/frontend/base/default/template/pricewaiter/widget.phtml
+++ b/app/design/frontend/base/default/template/pricewaiter/widget.phtml
@@ -27,11 +27,16 @@
 
 
     // prefer brand, but fallback to manufacturer attribute
+    // getAttributeText will fail when manufacturer is deleted.
+    // getResource -> getAttribute will safely give Object when attribute exists
     $brand = $_product->getData('brand');
-    $manufacturer = $_product->getAttributeText('manufacturer');
+    $manufacturer_id = $_product->getResource()->getAttribute('manufacturer');
 
-    if (!$brand && $manufacturer) {
-        $brand = $manufacturer;
+    if (!$brand && $manufacturer_id) {
+        $manufacturer = $_product->getAttributeText('manufacturer');
+        if ($manufacturer) {
+            $brand = $manufacturer;
+        }
     }
 
     $image = $_product->getImageUrl();

--- a/package.template.xml
+++ b/package.template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
     <name>nypwidget</name>
-    <version>2.1.4</version>
+    <version>2.1.5</version>
     <stability>stable</stability>
     <license uri="http://www.apache.org/licenses/LICENSE-2.0.html">Apache License, Version 2.0</license>
     <channel>community</channel>


### PR DESCRIPTION
Fallback to manufacturer attribute when brand is blank.

Only works when manufacturer is a "dropdown" type, which appears to be the default.